### PR TITLE
fix: use github token to get PR files

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,7 +13,7 @@ export JINAHUB_SLACK_WEBHOOK=$6
 
 pull_number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
 URL="https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${pull_number}/files"
-FILES=$(curl -s -X GET -G $URL | jq -r '.[] | select( (.filename | endswith("manifest.yml")) and (.status != "removed")) | .filename | rtrimstr("manifest.yml")')
+FILES=$(curl -s -X GET -G -H "Authorization: token $GITHUB_TOKEN" $URL | jq -r '.[] | select( (.filename | endswith("manifest.yml")) and (.status != "removed")) | .filename | rtrimstr("manifest.yml")')
 
 rc=0
 SUCCESS_TARGETS=()


### PR DESCRIPTION
Required for when the Hub Builder will be attached to a private repo