### PR TITLE
fix: always use the released version of jina on pip

### DIFF
--- a/.github/workflows/tests/EmptyExecutor/manifest.yml
+++ b/.github/workflows/tests/EmptyExecutor/manifest.yml
@@ -1,1 +1,1 @@
-version: 0.14
+version: 0.15

--- a/.github/workflows/tests/ImageReader/manifest.yml
+++ b/.github/workflows/tests/ImageReader/manifest.yml
@@ -7,6 +7,6 @@ author: Jina AI Dev-Team (dev-team@jina.ai)
 url: https://jina.ai
 vendor: Jina AI Limited
 documentation: https://github.com/jina-ai/jina-hub
-version: 0.0.14
+version: 0.0.15
 license: apache-2.0
 keywords: [Some keywords to describe the executor, separated by commas]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,6 +14,8 @@ export JINA_VERSION=$7
 if [ "$JINA_VERSION" != "latest" ]
 then
   pip install 'jina==${JINA_VERSION}'
+else
+  pip install jina
 fi
 
 pull_number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")


### PR DESCRIPTION
fix: always use the released version of jina on pip