### PR TITLE
feat(dependabot): enable build on docker, req txt

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,6 +30,7 @@ jobs:
         continue-on-error: true
         with:
           push: true
+          jina_hub_token: ${{ secrets.JINA_DEV_BOT }}
           dockerhub_username: ${{secrets.JINAHUB_DOCKER_USER}}
           dockerhub_password: ${{secrets.JINAHUB_DOCKER_PWD}}
       - name: Get the output

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
         continue-on-error: true
         with:
           push: true
-          jina_hub_token: ${{ secrets.JINA_DEV_BOT }}
+          jina_hub_token: ${{ github.token }}
           dockerhub_username: ${{secrets.JINAHUB_DOCKER_USER}}
           dockerhub_password: ${{secrets.JINAHUB_DOCKER_PWD}}
       - name: Get the output

--- a/.github/workflows/tests/EmptyExecutor/manifest.yml
+++ b/.github/workflows/tests/EmptyExecutor/manifest.yml
@@ -1,1 +1,1 @@
-version: 0.18
+version: 0.19

--- a/.github/workflows/tests/ImageReader/__init__.py
+++ b/.github/workflows/tests/ImageReader/__init__.py
@@ -2,25 +2,31 @@ import io
 from typing import Dict
 
 import numpy as np
+
+from jina.executors.decorators import single
 from jina.executors.crafters import BaseCrafter
 
 
 class ImageReader(BaseCrafter):
     """
-    :class:`ImageReader` loads the image from the given file path and save the `ndarray` of the image in the Document.
+    Load image file and craft it into image matrix.
+
+    :class:`ImageReader` loads the image from the given file
+        path and save the `ndarray` of the image in the Document.
+
+    :param channel_axis: the axis id of the color channel.
+        The ``-1`` indicates the color channel info at the last axis
     """
 
     def __init__(self, channel_axis: int = -1, *args, **kwargs):
-        """
-        :class:`ImageReader` load an image file and craft into image matrix.
-
-        :param channel_axis: the axis id of the color channel, ``-1`` indicates the color channel info at the last axis
-        """
         super().__init__(*args, **kwargs)
         self.channel_axis = channel_axis
 
+    @single(slice_nargs=2)
     def craft(self, buffer: bytes, uri: str, *args, **kwargs) -> Dict:
         """
+        Read image file and craft it into image matrix.
+
         Read the image from the given file path that specified in `buffer` and save the `ndarray` of the image in
             the `blob` of the document.
 
@@ -39,4 +45,4 @@ class ImageReader(BaseCrafter):
         img = np.array(raw_img).astype('float32')
         if self.channel_axis != -1:
             img = np.moveaxis(img, -1, self.channel_axis)
-        return dict(weight=1., blob=img)
+        return dict(blob=img)

--- a/.github/workflows/tests/ImageReader/manifest.yml
+++ b/.github/workflows/tests/ImageReader/manifest.yml
@@ -7,6 +7,6 @@ author: Jina AI Dev-Team (dev-team@jina.ai)
 url: https://jina.ai
 vendor: Jina AI Limited
 documentation: https://github.com/jina-ai/jina-hub
-version: 0.0.18
+version: 0.0.19
 license: apache-2.0
 keywords: [Some keywords to describe the executor, separated by commas]

--- a/.github/workflows/tests/ImageReader/tests/test_imagereader.py
+++ b/.github/workflows/tests/ImageReader/tests/test_imagereader.py
@@ -1,5 +1,4 @@
 import io
-import os
 
 import numpy as np
 from PIL import Image
@@ -16,22 +15,26 @@ def create_test_image(output_fn, size_width=50, size_height=50):
 
 def test_io_uri():
     crafter = ImageReader()
-    tmp_fn = os.path.join(crafter.current_workspace, 'test.jpeg')
+    tmp_fn = crafter.get_file_from_workspace('test.jpeg')
     img_size = 50
     create_test_image(tmp_fn, size_width=img_size, size_height=img_size)
-    test_doc = crafter.craft(buffer=None, uri=tmp_fn)
-    assert test_doc['blob'].shape == (img_size, img_size, 3)
+    test_docs = crafter.craft([None, None], np.stack([tmp_fn, tmp_fn]))
+    assert len(test_docs) == 2
+    for test_doc in test_docs:
+        assert test_doc['blob'].shape == (img_size, img_size, 3)
 
 
 def test_io_buffer():
     crafter = ImageReader()
-    tmp_fn = os.path.join(crafter.current_workspace, 'test.jpeg')
+    tmp_fn = crafter.get_file_from_workspace('test.jpeg')
     img_size = 50
     create_test_image(tmp_fn, size_width=img_size, size_height=img_size)
     image_buffer = io.BytesIO()
     img = Image.open(tmp_fn)
     img.save(image_buffer, format='PNG')
     image_buffer.seek(0)
-    test_doc = crafter.craft(buffer=image_buffer.getvalue(), uri=None)
-    assert test_doc['blob'].shape == (img_size, img_size, 3)
-    np.testing.assert_almost_equal(test_doc['blob'], np.array(img).astype('float32'))
+    test_docs = crafter.craft(np.stack([image_buffer.getvalue(), image_buffer.getvalue()]), [None, None])
+    assert len(test_docs) == 2
+    for test_doc in test_docs:
+        assert test_doc['blob'].shape == (img_size, img_size, 3)
+        np.testing.assert_almost_equal(test_doc['blob'], np.array(img).astype('float32'))

--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,6 @@ inputs:
   jina_hub_token:
     description: 'access token for jina hub login'
     required: true
-    default: ${{ secrets.JINA_DEV_BOT }}
   dockerhub_username:
     description: 'user name of the Docker registry'
     required: false

--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,8 @@ inputs:
     default: 'False'
   jina_hub_token:
     description: 'access token for jina hub login'
-    required: true
+    required: false
+    default: ${{ github.token }}
   dockerhub_username:
     description: 'user name of the Docker registry'
     required: false

--- a/action.yml
+++ b/action.yml
@@ -14,8 +14,8 @@ inputs:
     default: 'False'
   jina_hub_token:
     description: 'access token for jina hub login'
-    required: false
-    default: ${{ github.token }}
+    required: true
+    default: ${{ secrets.JINA_DEV_BOT }}
   dockerhub_username:
     description: 'user name of the Docker registry'
     required: false


### PR DESCRIPTION
This enables PRs from `dependabot`. 
Any PR created by `dependabot` would only change either `Dockerfile` or `requirements.txt` and not `manifest.yml`. Hence, we validate if the user that created the PR is `depenabot[bot]` and allow building.