### PR TITLE
fix: use git for pip installation

### DIFF
--- a/.github/workflows/tests/ImageReader/requirements.txt
+++ b/.github/workflows/tests/ImageReader/requirements.txt
@@ -1,2 +1,2 @@
-jina
+git+https://github.com/jina-ai/jina.git
 Pillow

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-jina[docker]
+git+https://github.com/jina-ai/jina.git#egg=jina[docker]


### PR DESCRIPTION
use git for pip installation